### PR TITLE
remove hlint from test dependencies

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -34,6 +34,5 @@ tests:
     ghc-options:      -Wall
     dependencies:
       - hscc
-      - hlint        >= 3.2 && < 3.3
       - hpc-codecov  >= 0.2 && < 0.3
       - hspec        >= 2.0


### PR DESCRIPTION
makes CI builds much faster, not sure why tbh